### PR TITLE
removeChild drops ownership to avoid memory leak; take ownership of the ...

### DIFF
--- a/frameworks/core_foundation/views/view/manipulation.js
+++ b/frameworks/core_foundation/views/view/manipulation.js
@@ -115,6 +115,9 @@ SC.View.reopen(
     // set parentView of child
     view.set('parentView', this);
 
+    // take ownership of child
+    view.set('owner', this);
+
     // add to childView's array.
     var idx, childViews = this.get('childViews') ;
     if (childViews.needsClone) { this.set(childViews = []); }


### PR DESCRIPTION
...child record. This fixes the bug wherein Endash tables have no visible contents.
