### PR TITLE
Update doc strings to better conform to jsDoc spec. Use Object instead o...

### DIFF
--- a/frameworks/datastore/system/child_array.js
+++ b/frameworks/datastore/system/child_array.js
@@ -257,7 +257,7 @@ SC.ChildArray = SC.Object.extend(SC.Enumerable, SC.Array,
   /**
     Invoked whenever the children array changes.  Observes changes.
 
-    @param {SC.Array} keys optional
+    @param {SC.Array} (keys)
     @returns {SC.ChildArray} itself.
   */
   recordPropertyDidChange: function(keys) {
@@ -270,8 +270,8 @@ SC.ChildArray = SC.Object.extend(SC.Enumerable, SC.Array,
     
     will cause the entire array to reset
     
-    @param {SC.Array} keys optional
-    @param {Boolean} doReset optional
+    @param {SC.Array} (keys)
+    @param {Boolean} (doReset)
     @returns {SC.ChildArray} itself.
   */
   _performRecordPropertyChange: function(keys, doReset){

--- a/frameworks/datastore/system/query.js
+++ b/frameworks/datastore/system/query.js
@@ -317,7 +317,7 @@ SC.Query = SC.Object.extend(SC.Copyable, SC.Freezable,
     used when computing a query locally.
 
     @param {SC.Record} record the record to check
-    @param {Hash} parameters optional override parameters
+    @param {Object} (parameters) override parameters
     @returns {Boolean} YES if record belongs, NO otherwise
   */
   contains: function(record, parameters) {
@@ -1350,8 +1350,8 @@ SC.Query.mixin( /** @scope SC.Query */ {
 
     @param {String} location the query location.
     @param {SC.Record|Array} recordType the record type or types.
-    @param {String} conditions optional conditions
-    @param {Hash} params optional params. or pass multiple args.
+    @param {String} (conditions) optional conditions
+    @param {Object} (params) optional params. or pass multiple args.
     @returns {SC.Query}
   */
   build: function(location, recordType, conditions, params) {
@@ -1440,8 +1440,8 @@ SC.Query.mixin( /** @scope SC.Query */ {
     the parameters you can pass to this method, see `SC.Query.build()`.
 
     @param {SC.Record|Array} recordType the record type or types.
-    @param {String} conditions optional conditions
-    @param {Hash} params optional params. or pass multiple args.
+    @param {String} (conditions) conditions
+    @param {Object} (params) params. or pass multiple args.
     @returns {SC.Query}
   */
   local: function(recordType, conditions, params) {
@@ -1453,8 +1453,8 @@ SC.Query.mixin( /** @scope SC.Query */ {
     the parameters you can pass to this method, see `SC.Query.build()`.
 
     @param {SC.Record|Array} recordType the record type or types.
-    @param {String} conditions optional conditions
-    @param {Hash} params optional params. or pass multiple args.
+    @param {String} (conditions) conditions
+    @param {Object} (params) params. or pass multiple args.
     @returns {SC.Query}
   */
   remote: function(recordType, conditions, params) {

--- a/frameworks/datastore/system/store.js
+++ b/frameworks/datastore/system/store.js
@@ -130,7 +130,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
         .. edit edit edit
         store.commitChanges().destroy();
 
-    @param {Hash} attrs optional attributes to set on new store
+    @param {Object} attrs optional attributes to set on new store
     @param {Class} newStoreClass optional the class of the newly-created nested store (defaults to SC.NestedStore)
     @returns {SC.NestedStore} new nested store chained to receiver
   */
@@ -304,7 +304,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     longer be reflected in this store until you reset.
 
     @param {Number} storeKey key to retrieve
-    @returns {Hash} data hash or null
+    @returns {Object} data hash or null
   */
   readDataHash: function(storeKey) {
     return this.dataHashes[storeKey];
@@ -319,7 +319,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     `dataHashDidChange()` when you make edits to record the change.
 
     @param {Number} storeKey the store key to retrieve
-    @returns {Hash} the attributes hash
+    @returns {Object} the attributes hash
   */
   readEditableDataHash: function(storeKey) {
     // read the value - if there is no hash just return; nothing to do
@@ -378,7 +378,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     Pass the optional status to edit the status as well.
 
     @param {Number} storeKey the store key to write
-    @param {Hash} hash the new hash
+    @param {Object} hash the new hash
     @param {String} status the new hash status
     @returns {SC.Store} receiver
   */
@@ -463,7 +463,6 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {Number} storeKey the store key
     @param {String} newStatus the new status
-    @param {SC.Error} error optional error object
     @returns {SC.Store} receiver
   */
   writeStatus: function(storeKey, newStatus) {
@@ -480,8 +479,8 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {Number|Array} storeKeys one or more store keys that changed
     @param {Number} rev optional new revision number. normally leave null
-    @param {Boolean} statusOnly (optional) YES if only status changed
-    @param {String} key that changed (optional)
+    @param {Boolean} (statusOnly) YES if only status changed
+    @param {String} (key) that changed
     @returns {SC.Store} receiver
   */
   dataHashDidChange: function(storeKeys, rev, statusOnly, key) {
@@ -1106,8 +1105,8 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     a record to the server, call `commitChanges()` on the store.
 
     @param {SC.Record} recordType the record class to use on creation
-    @param {Hash} dataHash the JSON attributes to assign to the hash.
-    @param {String} id (optional) id to assign to record
+    @param {Object} dataHash the JSON attributes to assign to the hash.
+    @param {String} (id) id to assign to record
 
     @returns {SC.Record} Returns the created record
   */
@@ -1216,7 +1215,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record|Array} recordTypes class or array of classes
     @param {Array} dataHashes array of data hashes
-    @param {Array} ids (optional) ids to assign to records
+    @param {Array} (ids) ids to assign to records
     @returns {Array} array of materialized record instances.
   */
   createRecords: function(recordTypes, dataHashes, ids) {
@@ -1240,7 +1239,8 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record} recordType the recordType
     @param {String} id the record id
-    @param {Number} storeKey (optional) if passed, ignores recordType and id
+    @param {Number} (storeKey) if passed, ignores recordType and id
+    @param {Number} (newStatus) the new record status to apply
     @returns {SC.Store} receiver
   */
   unloadRecord: function(recordType, id, storeKey, newStatus) {
@@ -1289,8 +1289,9 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     unload records this way.
 
     @param {SC.Record|Array} recordTypes class or array of classes
-    @param {Array} ids (optional) ids to unload
-    @param {Array} storeKeys (optional) store keys to unload
+    @param {Array} (ids) ids to unload
+    @param {Array} (storeKeys) store keys to unload
+    @param {Number} (newStatus) the new record status to apply
     @returns {SC.Store} receiver
   */
   unloadRecords: function(recordTypes, ids, storeKeys, newStatus) {
@@ -1333,7 +1334,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record} recordType the recordType
     @param {String} id the record id
-    @param {Number} storeKey (optional) if passed, ignores recordType and id
+    @param {Number} (storeKey) if passed, ignores recordType and id
     @returns {SC.Store} receiver
   */
   destroyRecord: function(recordType, id, storeKey) {
@@ -1404,7 +1405,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record|Array} recordTypes class or array of classes
     @param {Array} ids ids to destroy
-    @param {Array} storeKeys (optional) store keys to destroy
+    @param {Array} (storeKeys) store keys to destroy
     @returns {SC.Store} receiver
   */
   destroyRecords: function(recordTypes, ids, storeKeys) {
@@ -1470,7 +1471,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     Record to be removed from the store.
 
     @param {Number} childStoreKey storeKey to unregister
-    @param {Boolean} [isParent] used internally by unloadRecord to unregister all child records
+    @param {Boolean} (isParent) used internally by unloadRecord to unregister all child records
   */
   unregisterChildFromParent: function(childStoreKey, isParent) {
     var crs, oldPk, storeKeys,
@@ -1553,9 +1554,9 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record} recordType the recordType
     @param {String} id the record id
-    @param {Number} storeKey (optional) if passed, ignores recordType and id
-    @param {String} key that changed (optional)
-    @param {Boolean} if the change is to statusOnly (optional)
+    @param {Number} (storeKey) if passed, ignores recordType and id
+    @param {String} (key) key that changed
+    @param {Boolean} (statusOnly) if the only change is to the record's status
     @returns {SC.Store} receiver
   */
   recordDidChange: function(recordType, id, storeKey, key, statusOnly) {
@@ -1612,7 +1613,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record|Array} recordTypes class or array of classes
     @param {Array} ids ids to destroy
-    @param {Array} storeKeys (optional) store keys to destroy
+    @param {Array} (storeKeys) store keys to destroy
     @returns {SC.Store} receiver
   */
   recordsDidChange: function(recordTypes, ids, storeKeys) {
@@ -1650,7 +1651,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record|Array} recordTypes class or array of classes
     @param {Array} ids ids to retrieve
-    @param {Array} storeKeys (optional) store keys to retrieve
+    @param {Array} (storeKeys) store keys to retrieve
     @param {Boolean} isRefresh
     @param {Function|Array} callback function or array of functions
     @returns {Array} storeKeys to be retrieved
@@ -1809,9 +1810,9 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record} recordType class
     @param {String} id id to retrieve
-    @param {Number} storeKey (optional) store key
+    @param {Number} (storeKey) store key
     @param {Boolean} isRefresh
-    @param {Function} callback (optional)
+    @param {Function} callback
     @returns {Number} storeKey that was retrieved
   */
   retrieveRecord: function(recordType, id, storeKey, isRefresh, callback) {
@@ -1839,8 +1840,8 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record} recordType the expected record type
     @param {String} id to id of the record to load
-    @param {Number} storeKey (optional) optional store key
-    @param {Function} callback (optional) when refresh completes
+    @param {Number} (storeKey) optional store key
+    @param {Function} (callback) when refresh completes
     @returns {Boolean} YES if the retrieval was a success.
   */
   refreshRecord: function(recordType, id, storeKey, callback) {
@@ -1854,8 +1855,8 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record|Array} recordTypes class or array of classes
     @param {Array} ids ids to destroy
-    @param {Array} storeKeys (optional) store keys to destroy
-    @param {Function} callback (optional) when refresh completes
+    @param {Array} (storeKeys) store keys to destroy
+    @param {Function} (callback) when refresh completes
     @returns {Boolean} YES if the retrieval was a success.
   */
   refreshRecords: function(recordTypes, ids, storeKeys, callback) {
@@ -1874,9 +1875,9 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Array} recordTypes the expected record types (SC.Record)
     @param {Array} ids to commit
     @param {SC.Set} storeKeys to commit
-    @param {Hash} params optional additional parameters to pass along to the
+    @param {Object} (params) optional additional parameters to pass along to the
       data source
-    @param {Function|Array} callback function or array of callbacks
+    @param {Function|Array} (callback) function or array of callbacks
 
     @returns {Boolean} if the action was succesful.
   */
@@ -1970,9 +1971,9 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.Record} recordType the expected record type
     @param {String} id the id of the record to commit
     @param {Number} storeKey the storeKey of the record to commit
-    @param {Hash} params optional additional params that will passed down
+    @param {Object} (params) optional additional params that will passed down
       to the data source
-    @param {Function|Array} callback function or array of functions
+    @param {Function|Array} (callback) function or array of functions
     @returns {Boolean} if the action was successful.
   */
   commitRecord: function(recordType, id, storeKey, params, callback) {
@@ -2000,7 +2001,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record|Array} recordTypes class or array of classes
     @param {Array} ids ids to destroy
-    @param {Array} storeKeys (optional) store keys to destroy
+    @param {Array} (storeKeys) store keys to destroy
     @returns {SC.Store} the store.
   */
   cancelRecords: function(recordTypes, ids, storeKeys) {
@@ -2045,7 +2046,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record|Array} recordTypes class or array of classes
     @param {Array} ids ids to destroy
-    @param {Array} storeKeys (optional) store keys to destroy
+    @param {Array} (storeKeys) store keys to destroy
     @returns {SC.Store} the store.
   */
   cancelRecord: function(recordType, id, storeKey) {
@@ -2088,7 +2089,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record} recordType the record type
     @param {Array} dataHash to update
-    @param {Array} id optional.  if not passed lookup on the hash
+    @param {Array} (id) if not passed lookup on the hash
     @returns {String} store keys assigned to these id
   */
   loadRecord: function(recordType, dataHash, id) {
@@ -2134,7 +2135,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {SC.Record} recordTypes the record type or array of record types
     @param {Array} dataHashes array of data hashes to update
-    @param {Array} ids optional array of ids.  if not passed lookup on hashes
+    @param {Array} (ids) optional array of ids.  if not passed lookup on hashes
     @returns {Array} store keys assigned to these ids
   */
   loadRecords: function(recordTypes, dataHashes, ids) {
@@ -2254,8 +2255,8 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     required when you commit a record that does not have an id yet.
 
     @param {Number} storeKey record store key to change to READY_CLEAN state
-    @param {Hash} dataHash optional data hash to replace current hash
-    @param {Object} newId optional new id to replace the old one
+    @param {Object} (dataHash) optional data hash to replace current hash
+    @param {Object} (newId) optional new id to replace the old one
     @returns {SC.Store} receiver
   */
   dataSourceDidComplete: function(storeKey, dataHash, newId) {
@@ -2327,7 +2328,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     Converts the passed record into an error object.
 
     @param {Number} storeKey record store key to error
-    @param {SC.Error} error [optional] an SC.Error instance to associate with storeKey
+    @param {SC.Error} (error) an SC.Error instance to associate with storeKey
     @returns {SC.Store} receiver
   */
   dataSourceDidError: function(storeKey, error) {
@@ -2369,8 +2370,8 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {Class} recordType the SC.Record subclass
     @param {Object} id the record id or null
-    @param {Hash} dataHash data hash to load
-    @param {Number} storeKey optional store key.
+    @param {Object} dataHash data hash to load
+    @param {Number} (storeKey) optional store key.
     @returns {Number|Boolean} storeKey if push was allowed, NO if not
   */
   pushRetrieve: function(recordType, id, dataHash, storeKey) {
@@ -2425,8 +2426,8 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {Class} recordType the SC.Record subclass
     @param {Object} id the record id or null
-    @param {SC.Error} error [optional] an SC.Error instance to associate with id or storeKey
-    @param {Number} storeKey optional store key.
+    @param {SC.Error} (error) an SC.Error instance to associate with id or storeKey
+    @param {Number} (storeKey) optional store key.
     @returns {Number|Boolean} storeKey if push was allowed, NO if not
   */
   pushError: function(recordType, id, error, storeKey) {
@@ -2978,7 +2979,7 @@ SC.Store.find = function(guid, recordType) {
   compatibility.  You should use the newer `findAll()` defined on `SC.Store`
   instead.
 
-  @param {Hash} filter search parameters
+  @param {Object} filter search parameters
   @param {SC.Record} recordType type of record to find
   @returns {SC.RecordArray} result set
 */

--- a/frameworks/runtime/ext/function.js
+++ b/frameworks/runtime/ext/function.js
@@ -123,7 +123,7 @@ SC.mixin(Function.prototype,
     conditionally exclude part of it. This helps to keep your code more
     compact and easier to maintain.
 
-    @param {String...} dependentKeys optional set of dependent keys
+    @param {String...} (dependentKeys) optional set of dependent keys
     @returns {Function} the declared function instance
   */
   property: function() {
@@ -141,7 +141,7 @@ SC.mixin(Function.prototype,
     If you do not specify this option, computed properties are assumed to be
     not cacheable.
 
-    @param {Boolean} aFlag optionally indicate cacheable or no, default YES
+    @param {Boolean} (aFlag) optionally indicate cacheable or no, default YES
     @returns {Function} receiver, useful for chaining calls.
   */
   cacheable: function(aFlag) {
@@ -162,7 +162,7 @@ SC.mixin(Function.prototype,
     If you do not specify this option, properties are assumed to be
     non-volatile.
 
-    @param {Boolean} aFlag optionally indicate state, default to YES
+    @param {Boolean} (aFlag) optionally indicate state, default to YES
     @returns {Function} receiver, useful for chaining calls.
   */
   idempotent: function(aFlag) {

--- a/frameworks/runtime/system/object.js
+++ b/frameworks/runtime/system/object.js
@@ -61,9 +61,9 @@ SC._detect_base = function _detect_base(func, parent, name) {
   - prepping a list of bindings, observers, and dependent keys
   - caching local observers so they don't need to be manually constructed.
 
-  @param {Hash} base hash
-  @param {Hash} extension
-  @returns {Hash} base hash
+  @param {Object} base hash
+  @param {Object} extension
+  @returns {Object} base hash
 */
 SC._object_extend = function _object_extend(base, ext, proto) {
   if (!ext) { throw "SC.Object.extend expects a non-null value.  Did you forget to 'sc_require' something?  Or were you passing a Protocol to extend() as if it were a mixin?"; }
@@ -284,7 +284,7 @@ SC.mixin(SC.Object, /** @scope SC.Object */ {
 
     This is a shorthand for calling SC.mixin(MyClass, props...);
 
-    @param {Hash} props the properties you want to add.
+    @param Object} props the properties you want to add.
     @returns {Object} receiver
   */
   mixin: function(props) {
@@ -318,7 +318,7 @@ SC.mixin(SC.Object, /** @scope SC.Object */ {
     do important setup, you must be sure to always call sc_super() somewhere
     in your init() to allow the normal setup to proceed.
 
-    @param {Hash} props the methods of properties you want to add
+    @param {Object} props the methods of properties you want to add
     @returns {Class} A new object class
   */
   extend: function(props) {
@@ -411,7 +411,7 @@ SC.mixin(SC.Object, /** @scope SC.Object */ {
 
     You can pass any hash of properties to this method, including mixins.
 
-    @param {Hash} props
+    @param {Object} props
       optional hash of method or properties to add to the instance.
 
     @returns {SC.Object} new instance of the receiver class.
@@ -499,7 +499,7 @@ SC.mixin(SC.Object, /** @scope SC.Object */ {
     This method works just like extend() except that it will also preserve
     the passed attributes.
 
-    @param {Hash} attrs Attributes to add to view
+    @param {Object} attrs Attributes to add to view
     @returns {Class} SC.Object subclass to create
     @function
   */
@@ -577,7 +577,7 @@ SC.Object.prototype = {
 
           instance.get('foo') => "bar"
 
-    @param {Hash} ext a hash to copy.  Only one.
+    @param {Object} ext a hash to copy.  Only one.
     @returns {Object} receiver
   */
   mixin: function() {


### PR DESCRIPTION
...f Hash, and place optional parameter names in parenthesis.