### PR TITLE
Fix selection for SC.ListView

### DIFF
--- a/frameworks/desktop/views/collection.js
+++ b/frameworks/desktop/views/collection.js
@@ -1279,7 +1279,7 @@ SC.CollectionView = SC.View.extend(SC.CollectionViewDelegate, SC.CollectionConte
   */
   layerIdFor: function(idx) {
     var ret = this._TMP_LAYERID;
-    ret[0] = SC.guidFor(this);
+    ret[0] = this.get('layerId');
     ret[1] = idx;
     return ret.join('-');
   },


### PR DESCRIPTION
When a layerId was set for an SC.ListView, no items could be selected. This patch sets the contained items' layerId based on the layerId of the parent container rather than on the guid of the parent container, restoring selectability.
